### PR TITLE
Bugfix: Use space as delimiter.

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-#!/usr/bin/env bash
-
 # Get all tags from https://github.com/openresty/openresty.
 tags=$(curl https://api.github.com/repos/openresty/openresty/git/refs/tags 2> /dev/null)
 
 # Output all available tags matched asdf-vm version format.
-echo $tags | grep -oP 'refs\/tags\/v\K([^"]+)'
+echo $tags | grep -oP 'refs\/tags\/v\K([^"]+)' | tr '\n' ' ' | sed -E 's/\s+$//g'
 


### PR DESCRIPTION
Follow asdf-vm standard to use space as delimiter instead of line-break.